### PR TITLE
Add zec.rocks servers to the list

### DIFF
--- a/lib/coin/zcash.dart
+++ b/lib/coin/zcash.dart
@@ -22,6 +22,11 @@ class ZcashCoin extends CoinBase {
     LWInstance("Zcash Infra (France)", "https://lwd5.zcash-infra.com:9067"),
     LWInstance("Zcash Infra (USA)", "https://lwd6.zcash-infra.com:9067"),
     LWInstance("Zcash Infra (Brazil)", "https://lwd7.zcash-infra.com:9067"),
+    LWInstance("Zec.rocks (Global)", "https://zec.rocks:443"),
+    LWInstance("Zec.rocks (NA)", "https://na.zec.rocks:443"),
+    LWInstance("Zec.rocks (SA)", "https://sa.zec.rocks:443"),
+    LWInstance("Zec.rocks (EU)", "https://eu.zec.rocks:443"),
+    LWInstance("Zec.rocks (AP)", "https://ap.zec.rocks:443"),
   ];
   int defaultAddrMode = 0;
   int defaultUAType = 7; // TSO


### PR DESCRIPTION
This pull request adds Zec.rocks to YWallet as a lightwalletd server option.

Zec.rocks is new lightwalletd infrastructure [funded by a ZCG award](https://forum.zcashcommunity.com/t/rfp-zcash-lightwalletd-infrastructure-development-and-maintenance/47080). It is globally load-balanced, currently across four regions, with an emphasis on using dedicated hardware and infrastructure-as-code. We are in the process of open-sourcing the Kubernetes helm charts used to maintain this new infrastructure to make it easier for people to host their own light wallet servers.

The "zec.rocks:443" endpoint is globally load-balanced using anycast, automatically routing users to their closest region.

Thank you for reviewing.